### PR TITLE
set state bug

### DIFF
--- a/frontend/lib/classes/eventHelper.dart
+++ b/frontend/lib/classes/eventHelper.dart
@@ -30,6 +30,9 @@ class EventHelper {
       var url = "https://www.trumba.com/calendars/sacramento-state-events.json";
       final response = await RouteHandler.dio.get(url);
       var results = response.data;
+
+      //I need to fix the set state bug, if you click to another page while events are fetching,
+      //an error will be thrown because set state is called on an non-existent widget, RIP.
       setState(() {
         for (var event in results) {
           DateTime dateTime = DateTime.parse(event['startDateTime']);


### PR DESCRIPTION
Events is mostly working, there is a set state bug, I need to re-write the whole thing, maybe using Future widgets, the problem is if someone clicks away while events are fetching, setState will be called on a non-existent widget.